### PR TITLE
QTY-3448b: Add config file

### DIFF
--- a/.idea/agilix-buzz-client.iml
+++ b/.idea/agilix-buzz-client.iml
@@ -11,19 +11,25 @@
     </content>
     <orderEntry type="jdk" jdkName="rbenv: 3.1.4" jdkType="RUBY_SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" scope="PROVIDED" name="addressable (v2.8.4, rbenv: 3.1.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="agilix (v0.8.2, rbenv: 3.1.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="builder (v3.2.4, rbenv: 3.1.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="bundler (v2.4.14, rbenv: 3.1.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="coderay (v1.1.3, rbenv: 3.1.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="crack (v0.4.5, rbenv: 3.1.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="dotenv (v2.8.1, rbenv: 3.1.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="hashdiff (v1.0.1, rbenv: 3.1.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="httparty (v0.21.0, rbenv: 3.1.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="method_source (v1.0.0, rbenv: 3.1.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="mini_mime (v1.1.2, rbenv: 3.1.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="minitest (v5.18.1, rbenv: 3.1.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="multi_xml (v0.6.0, rbenv: 3.1.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="pry (v0.14.2, rbenv: 3.1.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="public_suffix (v5.0.1, rbenv: 3.1.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rake (v13.0.6, rbenv: 3.1.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rexml (v3.2.5, rbenv: 3.1.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="vcr (v6.2.0, rbenv: 3.1.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="webmock (v3.18.1, rbenv: 3.1.4) [gem]" level="application" />
   </component>
   <component name="RakeTasksCache">
     <option name="myRootTask">

--- a/lib/agilix.rb
+++ b/lib/agilix.rb
@@ -10,7 +10,7 @@ module Agilix
   autoload :Agilix, "agilix/version"
 
   autoload :Api, "agilix/buzz/api"
-
+  autoload :Configuration, "agilix/buzz/configuration"
   autoload :Authentication, "agilix/buzz/commands/authentication"
   autoload :Course, "agilix/buzz/commands/course"
   autoload :Domain, "agilix/buzz/commands/domain"

--- a/lib/agilix.rb
+++ b/lib/agilix.rb
@@ -1,35 +1,15 @@
-
 # require "active_support/all"
 require "httparty"
 require "ostruct"
-
-require "agilix/buzz/commands/authentication"
-require "agilix/buzz/commands/course"
-require "agilix/buzz/commands/domain"
-require "agilix/buzz/commands/enrollment"
-require "agilix/buzz/commands/general"
-require "agilix/buzz/commands/library"
-require "agilix/buzz/commands/report"
-require "agilix/buzz/commands/resource"
-require "agilix/buzz/commands/right"
-require "agilix/buzz/commands/user"
-
-require "agilix/buzz/api"
 require "agilix/buzz/configuration"
-require "agilix/version"
-
-
-
 module Agilix
   class << self
     attr_accessor :configuration
   end
 
-
   autoload :Agilix, "agilix/version"
 
   autoload :Api, "agilix/buzz/api"
-  autoload :Configuration, "agilix/buzz/configuration"
 
   autoload :Authentication, "agilix/buzz/commands/authentication"
   autoload :Course, "agilix/buzz/commands/course"
@@ -42,9 +22,6 @@ module Agilix
   autoload :Right, "agilix/buzz/commands/right"
   autoload :User, "agilix/buzz/commands/user"
 
-  # Classes used to return a nicer object wrapping the response data
-  # autoload :Group, "schoology/objects/group"
-
   def self.configuration
     @configuration ||= Agilix::Buzz::Configuration.new
   end
@@ -54,9 +31,9 @@ module Agilix
   end
 
   def initialize
-    @agilix_buzz_username = self.class.configuration.oauth_consumer_key
-    @agilix_buzz_password = self.class.configuration.oauth_consumer_secret
-    @agilix_buzz_domain = self.class.configuration.url
+    @agilix_buzz_username = self.class.configuration.agilix_buzz_username
+    @agilix_buzz_password = self.class.configuration.agilix_buzz_password
+    @agilix_buzz_domain = self.class.configuration.agilix_buzz_domain
   end
 end
 

--- a/lib/agilix.rb
+++ b/lib/agilix.rb
@@ -15,17 +15,48 @@ require "agilix/buzz/commands/right"
 require "agilix/buzz/commands/user"
 
 require "agilix/buzz/api"
+require "agilix/buzz/configuration"
 require "agilix/version"
 
 
 
 module Agilix
-  module Buzz
-    class Api::AuthenticationError < StandardError
-      def initialize(msg="Could not Authenticate")
-        super
-      end
-    end
+  class << self
+    attr_accessor :configuration
+  end
 
+
+  autoload :Agilix, "agilix/version"
+
+  autoload :Api, "agilix/buzz/api"
+  autoload :Configuration, "agilix/buzz/configuration"
+
+  autoload :Authentication, "agilix/buzz/commands/authentication"
+  autoload :Course, "agilix/buzz/commands/course"
+  autoload :Domain, "agilix/buzz/commands/domain"
+  autoload :Enrollment, "agilix/buzz/commands/enrollment"
+  autoload :General, "agilix/buzz/commands/general"
+  autoload :Library, "agilix/buzz/commands/library"
+  autoload :Report, "agilix/buzz/commands/report"
+  autoload :Resource, "agilix/buzz/commands/resource"
+  autoload :Right, "agilix/buzz/commands/right"
+  autoload :User, "agilix/buzz/commands/user"
+
+  # Classes used to return a nicer object wrapping the response data
+  # autoload :Group, "schoology/objects/group"
+
+  def self.configuration
+    @configuration ||= Agilix::Buzz::Configuration.new
+  end
+
+  def self.configure
+    yield(configuration)
+  end
+
+  def initialize
+    @agilix_buzz_username = self.class.configuration.oauth_consumer_key
+    @agilix_buzz_password = self.class.configuration.oauth_consumer_secret
+    @agilix_buzz_domain = self.class.configuration.url
   end
 end
+

--- a/lib/agilix/buzz/configuration.rb
+++ b/lib/agilix/buzz/configuration.rb
@@ -1,0 +1,12 @@
+module Agilix::Buzz
+  class Configuration
+    attr_accessor :agilix_buzz_username, :agilix_buzz_password, :agilix_buzz_domain
+
+    def initialize
+      @agilix_buzz_username = nil
+      @agilix_buzz_password = nil
+      @agilix_buzz_domain = nil
+    end
+
+  end
+end

--- a/lib/agilix/buzz/configuration.rb
+++ b/lib/agilix/buzz/configuration.rb
@@ -1,12 +1,14 @@
-module Agilix::Buzz
-  class Configuration
-    attr_accessor :agilix_buzz_username, :agilix_buzz_password, :agilix_buzz_domain
+module Agilix
+  module Buzz
 
-    def initialize
-      @agilix_buzz_username = nil
-      @agilix_buzz_password = nil
-      @agilix_buzz_domain = nil
+    class Configuration
+      attr_accessor :agilix_buzz_username, :agilix_buzz_password, :agilix_buzz_domain
+
+      def initialize
+        @agilix_buzz_username = nil
+        @agilix_buzz_password = nil
+        @agilix_buzz_domain = nil
+      end
     end
-
   end
 end


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-3448)


## Purpose 
This config file is needed to allow support for the use of the username, password and domain that is needed for Cartman to interact with the Buzz api through the agilix-buzz-client gem.  The the agilix-buzz client is initialized and its commands/modules are autoloaded and managed in the agilix.rb file.

## Approach 
Added config file in the same manner as the Schoology Client gem.  Utilized the environmental variables that are stored for the username, password and domain for the attribute accessors and instance variables.  Add autoloading and initializers into the agilix.rb file, similar to the Schoology Client gem for initialization and management of the modules.

## Testing
Existing test suite still passes.  More testing is necessary from Cartman after this change is deployed to see if it all works together as expected.

## Screenshots/Video
<img width="847" alt="image" src="https://github.com/StrongMind/agilix-buzz-client/assets/80060671/3297484e-f685-496c-946e-f43f4bfda3ba">
